### PR TITLE
[CART]: Fix cartridges RAM r/w + registers

### DIFF
--- a/include/cartridge/cartridge.h
+++ b/include/cartridge/cartridge.h
@@ -107,6 +107,12 @@ struct cartridge {
     u32 rom_size;
 
     /**
+     * Actual size of the game's RAM. \n
+     * Depends on the \c ram_size inside the header
+     */
+    u32 ram_size;
+
+    /**
      * The actual content of the game's ROM. \n
      * \warning ROM stands for Read-Only memory, it should NEVER be modified.
      */

--- a/include/cartridge/memory.h
+++ b/include/cartridge/memory.h
@@ -28,7 +28,20 @@ extern struct chip_registers_t {
     // MBC1 registers
 
     u8 ram_g;
+
+    /**
+     * Determines which rom bank to access.
+     *
+     * Set to 1 by default.
+     */
     u8 rom_bank;
+
+    /**
+     * Determines which rom bank to access.
+     * Only used by MBC1 cartridges.
+     *
+     * Set to 1 by default.
+     */
     u8 ram_bank;
 
     /**
@@ -39,20 +52,6 @@ extern struct chip_registers_t {
      * 0= ROM_BANK2 only affects accesses to 0x4000-0x7FFF
      */
     bool mode;
-
-    // MBC2 registers
-
-    // TODO: change it to a static variable inside mbc2.c as it isn't used by
-    // any other MBC and may end up being confusing.
-
-    /**
-     * Determines which rom bank to access.
-     * Only used by MBC2 cartridges.
-     *
-     * Set to 1 by default.
-     */
-    u8 rom_b;
-
 } chip_registers;
 
 // Cartridge register addresses

--- a/include/cartridge/memory.h
+++ b/include/cartridge/memory.h
@@ -28,8 +28,8 @@ extern struct chip_registers_t {
     // MBC1 registers
 
     u8 ram_g;
-    u8 bank_1;
-    u8 bank_2;
+    u8 rom_bank;
+    u8 ram_bank;
 
     /**
      * Determines how the ROM_BANK2 register value is used during access

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -24,7 +24,7 @@ for test in $(find * -type f -and -executable); do
         FAILED=$((FAILED + 1))
     else
         echo -ne "$GREY- $test: $NC"
-        "./$test" > /dev/null
+        "./$test" &> /dev/null
         if [[ $? -eq 0 ]]; then
             echo -e "${GREEN}OK"
         else

--- a/src/cartridge/cartridge.c
+++ b/src/cartridge/cartridge.c
@@ -40,15 +40,15 @@ static bool check_multicart()
     cartridge.multicart = true;
 
     // Set BANK1 to zero
-    u8 bank2 = chip_registers.bank_2;
-    chip_registers.bank_1 = 0;
+    u8 bank2 = chip_registers.ram_bank;
+    chip_registers.rom_bank = 0;
     chip_registers.mode = true;
 
     // Loop through all four possiblbbe BANK2 values
-    for (chip_registers.bank_2 = 0b00; chip_registers.bank_2 <= 0b11;
-         ++chip_registers.bank_2) {
+    for (chip_registers.ram_bank = 0b00; chip_registers.ram_bank <= 0b11;
+         ++chip_registers.ram_bank) {
         // Look for the nintendo logo
-        printf("NEW BANK: %d\n", chip_registers.bank_2);
+        printf("NEW BANK: %d\n", chip_registers.ram_bank);
         for (size_t i = 0; i < sizeof(nintendo_logo); ++i) {
             printf("%x = %x, ", read_cartridge(0x0104 + i), nintendo_logo[i]);
             if (read_cartridge(0x0104 + i) != nintendo_logo[i]) {
@@ -61,7 +61,7 @@ static bool check_multicart()
 
     printf("%d\n", nb_games);
     cartridge.multicart = nb_games;
-    chip_registers.bank_2 = bank2;
+    chip_registers.ram_bank = bank2;
     chip_registers.mode = false; // Always initialized at false
     return cartridge.multicart;
 }

--- a/src/cartridge/cartridge.c
+++ b/src/cartridge/cartridge.c
@@ -83,6 +83,36 @@ bool load_cartridge(char *path)
     cartridge.rom = malloc(cartridge.rom_size);
     cartridge.multicart = false;
 
+    // Do the same for the RAM
+    // RAM size equivalent to the code inside the header:
+    //
+    // $00 = 0          No RAM
+    // $01 = Unused
+    // $02 = 8 KiB      1 bank
+    // $03 = 32 KiB     4 banks of 8 KiB each
+    // $04 = 128 KiB    16 banks of 8 KiB each
+    // $05 = 64 KiB     8 banks of 8 KiB each
+    const u8 ram_size_code = HEADER(cartridge)->ram_size;
+    switch (ram_size_code) {
+    case 2:
+        cartridge.ram_size = 2 << 13;
+        break;
+    case 3:
+        cartridge.ram_size = 2 << 15;
+        break;
+    case 4:
+        cartridge.ram_size = 2 << 17;
+        break;
+    case 5:
+        cartridge.ram_size = 2 << 16;
+        break;
+    default:
+        cartridge.ram_size = 0;
+        break;
+    }
+
+    cartridge.ram = malloc(cartridge.ram_size ? cartridge.ram_size : 1);
+
     rewind(rom);
     fread(cartridge.rom, 1, cartridge.rom_size, rom);
 

--- a/src/cartridge/mbc1.c
+++ b/src/cartridge/mbc1.c
@@ -28,9 +28,7 @@ WRITE_FUNCTION(mbc1)
     if (address < RAM_GATE) {
         // bits 7-4 are ignored during write
         chip_registers.ram_g = data & 0xF;
-        // FIXME: Euh ... just ... why? makes no sense ... what was i thinking?
-        // Update RAM access
-        ram_access = cartridge.rom[address] & 0b1010;
+        ram_access = chip_registers.ram_g == 0xA;
     } else if (address < ROM_BANK) {
         // bits 7-5 are ignored during write
         chip_registers.bank_1 = data & 0x1F;

--- a/src/cartridge/mbc1.c
+++ b/src/cartridge/mbc1.c
@@ -21,7 +21,7 @@
 #include "cartridge/memory.h"
 #include "utils/macro.h"
 
-static unsigned compute_physical_addresss(u16 address);
+static unsigned compute_physical_address(u16 address);
 
 WRITE_FUNCTION(mbc1)
 {
@@ -46,7 +46,9 @@ WRITE_FUNCTION(mbc1)
 
     // READ/WRITE AREA
     else if (VIDEO_RAM <= address && address < EXTERNAL_RAM && ram_access) {
-        cartridge.ram[compute_physical_addresss(address)] = data;
+        const u16 physical_address = compute_physical_address(address);
+        assert(physical_address < cartridge.ram_size);
+        cartridge.ram[physical_address] = data;
     }
 }
 
@@ -80,7 +82,7 @@ WRITE_16_FUNCTION(mbc1)
  *
  * For more explanations please refer to the given documentation.
  */
-static unsigned compute_physical_addresss(u16 address)
+static unsigned compute_physical_address(u16 address)
 {
     // In case the chip is MBC1M, the BANK1 register is actually 4 bit long
     u8 bank_size = cartridge.multicart ? 4 : 5;
@@ -121,7 +123,7 @@ READ_FUNCTION(mbc1)
     if (is_ram && !ram_access)
         return 0xFF; // Undefined value
 
-    unsigned physical_address = compute_physical_addresss(address);
+    unsigned physical_address = compute_physical_address(address);
 
     // TODO: gracefully throw an error
 

--- a/src/cartridge/mbc2.c
+++ b/src/cartridge/mbc2.c
@@ -20,14 +20,15 @@
 #include "cartridge/memory.h"
 #include "utils/macro.h"
 
+static unsigned compute_physical_adress(u16 address);
+
 WRITE_FUNCTION(mbc2)
 {
     // READ ONLY
     if (address < ROM_BANK && !BIT(address, 8)) {
         // bits 7-4 are ignored during write
         chip_registers.ram_g = data & 0xF;
-        // Update RAM access
-        ram_access = cartridge.rom[address] & 0b1010;
+        ram_access = chip_registers.ram_g == 0xA;
     } else if (address < ROM_BANK && BIT(address, 8)) {
         // bits 7-4 are ignored during write
         chip_registers.rom_b = data & 0xF;
@@ -38,18 +39,10 @@ WRITE_FUNCTION(mbc2)
     // READ/WRITE AREA
     else if (VIDEO_RAM <= address && address < EXTERNAL_RAM && ram_access) {
         // Upper 4 bits are ignored
-        cpu.memory[address] = data & 0xF;
+        const u16 physical_address = compute_physical_adress(address);
+        assert(physical_address < cartridge.ram_size);
+        cartridge.ram[physical_address] = data & 0xF;
     }
-}
-
-WRITE_16_FUNCTION(mbc2)
-{
-    // TODO: check for actual implementation
-
-    // Write the lower bytes after so that we keep the correct lower bits for
-    // when we update the registers
-    write_mbc2(address + 1, MSB(data));
-    write_mbc2(address, LSB(data));
 }
 
 /**
@@ -63,12 +56,12 @@ WRITE_16_FUNCTION(mbc2)
 static unsigned compute_physical_adress(u16 address)
 {
     if (VIDEO_RAM <= address && address < EXTERNAL_RAM)
-        return address;
+        return address - 0xA000;
 
     if (address < ROM_BANK)
-        return address & 0x3FF;
+        return address & 0x1FFF;
     if (address < ROM_BANK_SWITCHABLE)
-        return (chip_registers.rom_b << 13) + (address & 0x3FF);
+        return (chip_registers.rom_b << 13) + (address & 0x1FFF);
 
     assert(false && "MBC2: compute_physical_adress: invalid area");
 
@@ -77,28 +70,24 @@ static unsigned compute_physical_adress(u16 address)
 
 READ_FUNCTION(mbc2)
 {
-    if (VIDEO_RAM <= address && address < EXTERNAL_RAM && !ram_access)
+    const bool is_ram = VIDEO_RAM <= address && address < EXTERNAL_RAM;
+
+    if (is_ram && !ram_access)
         return 0xFF; // Undefined value
 
     unsigned physical_address = compute_physical_adress(address);
 
     // TODO: gracefully throw an error
-    assert(physical_address < cartridge.rom_size);
 
+    printf(">> computed %X\n", physical_address);
+
+    if (is_ram) {
+        assert(physical_address < cartridge.ram_size);
+        return cartridge.ram[physical_address];
+    }
+
+    assert(physical_address < cartridge.rom_size);
     return cartridge.rom[physical_address];
-}
-
-READ_16_FUNCTION(mbc2)
-{
-    if (VIDEO_RAM <= address && address < EXTERNAL_RAM && !ram_access)
-        return 0xFFFF; // Undefined value
-
-    unsigned physical_address = compute_physical_adress(address);
-
-    // TODO: gracefully throw an error
-    assert(physical_address < cartridge.rom_size);
-
-    return cartridge.rom[physical_address] + (cartridge.rom[address + 1] << 8);
 }
 
 DUMP_FUNCTION(mbc2)

--- a/src/cartridge/mbc2.c
+++ b/src/cartridge/mbc2.c
@@ -31,9 +31,9 @@ WRITE_FUNCTION(mbc2)
         ram_access = chip_registers.ram_g == 0xA;
     } else if (address < ROM_BANK && BIT(address, 8)) {
         // bits 7-4 are ignored during write
-        chip_registers.rom_b = data & 0xF;
-        if (!chip_registers.rom_b) // Can never be null
-            chip_registers.rom_b = 0b0001;
+        chip_registers.rom_bank = data & 0xF;
+        if (!chip_registers.rom_bank) // Can never be null
+            chip_registers.rom_bank = 0b0001;
     }
 
     // READ/WRITE AREA
@@ -62,9 +62,9 @@ static unsigned compute_physical_adress(u16 address)
         return address & 0x1FFF;
     if (address < ROM_BANK_SWITCHABLE) {
         // Switch to rom bank 1 of set to 0
-        if (!chip_registers.rom_b)
+        if (!chip_registers.rom_bank)
             return (1 << 14) | (address & 0x3FFF);
-        return (chip_registers.rom_b << 14) + (address & 0x3FFF);
+        return (chip_registers.rom_bank << 14) + (address & 0x3FFF);
     }
 
     assert(false && "MBC2: compute_physical_adress: invalid area");
@@ -83,7 +83,7 @@ READ_FUNCTION(mbc2)
 
     // TODO: gracefully throw an error
 
-    printf(">> computed %X\n", physical_address);
+    // printf(">> computed %X\n", physical_address);
 
     if (is_ram) {
         assert(physical_address < cartridge.ram_size);

--- a/src/cartridge/mbc2.c
+++ b/src/cartridge/mbc2.c
@@ -50,8 +50,8 @@ WRITE_FUNCTION(mbc2)
  * the ROMB register.
  *
  * Physical address is:
- * - 0x0000 - 0x3FFF: 0000 + 13 lower bits of address
- * - 0x4000 - 0x7FFF: ROMB + 13 lower bits of address
+ * - 0x0000 - 0x3FFF: 0000 + 14 lower bits of address
+ * - 0x4000 - 0x7FFF: ROMB + 14 lower bits of address
  */
 static unsigned compute_physical_adress(u16 address)
 {
@@ -60,8 +60,12 @@ static unsigned compute_physical_adress(u16 address)
 
     if (address < ROM_BANK)
         return address & 0x1FFF;
-    if (address < ROM_BANK_SWITCHABLE)
-        return (chip_registers.rom_b << 13) + (address & 0x1FFF);
+    if (address < ROM_BANK_SWITCHABLE) {
+        // Switch to rom bank 1 of set to 0
+        if (!chip_registers.rom_b)
+            return (1 << 14) | (address & 0x3FFF);
+        return (chip_registers.rom_b << 14) + (address & 0x3FFF);
+    }
 
     assert(false && "MBC2: compute_physical_adress: invalid area");
 

--- a/src/cartridge/mbc3.c
+++ b/src/cartridge/mbc3.c
@@ -120,13 +120,13 @@ WRITE_FUNCTION(mbc3)
         // Update RAM and RTC access
         ram_access = cartridge.rom[address] & 0b1010;
     } else if (address < ROM_BANK) {
-        chip_registers.bank_1 = data;
-        if (!chip_registers.bank_1) // Value can never be null
-            chip_registers.bank_1 = 1;
+        chip_registers.rom_bank = data;
+        if (!chip_registers.rom_bank) // Value can never be null
+            chip_registers.rom_bank = 1;
     } else if (address < ROM_BANK2) {
         // 00h - 03h: maps the corresponding external RAM bank
         if (data <= 0x3)
-            chip_registers.bank_2 = data & 0x3;
+            chip_registers.ram_bank = data & 0x3;
         // 08h - 0Ch: maps the corresponding RTC registers
         // (checked when accessing A000h-BFFFh)
         rtc_mapped_register = data;
@@ -178,16 +178,16 @@ static unsigned compute_physical_addresss(u16 address)
      * bits of the requested address and BANK2, if mode is set, 0b00 else.
      */
     if (VIDEO_RAM <= address && address < EXTERNAL_RAM) {
-        bank = chip_registers.mode ? chip_registers.bank_2 : 0b00;
+        bank = chip_registers.mode ? chip_registers.ram_bank : 0b00;
         return (address & 0x1FFF) + (bank << 13);
     }
 
     if (address < 0x4000) {
         if (chip_registers.mode)
-            bank = chip_registers.bank_2 << bank_size;
+            bank = chip_registers.ram_bank << bank_size;
     } else if (address < 0x8000) {
-        bank = chip_registers.bank_2 << bank_size;
-        bank += chip_registers.bank_1;
+        bank = chip_registers.ram_bank << bank_size;
+        bank += chip_registers.rom_bank;
     } else {
         // TODO: throw nice error
         assert(false && "MBC3: Reading an out of bounds address.");

--- a/src/cartridge/memory.c
+++ b/src/cartridge/memory.c
@@ -6,7 +6,7 @@
 #include "cartridge/memory.h"
 #include "utils/macro.h"
 
-struct chip_registers_t chip_registers = {0, 0, 0, false, 1};
+struct chip_registers_t chip_registers = {0, 1, 0, false};
 
 u8 read_cartridge(u16 address)
 {

--- a/src/cartridge/memory.c
+++ b/src/cartridge/memory.c
@@ -1,5 +1,7 @@
 #include "CPU/memory.h"
 
+#include <assert.h>
+
 #include "cartridge/cartridge.h"
 #include "cartridge/memory.h"
 #include "utils/macro.h"
@@ -11,6 +13,7 @@ u8 read_cartridge(u16 address)
     struct cartridge_header *rom = HEADER(cartridge);
 
     if (rom->type == ROM_ONLY) {
+        assert(address < cartridge.rom_size);
         return cartridge.rom[address];
     } else if (rom->type <= MBC1) {
         return read_mbc1(address);
@@ -34,6 +37,7 @@ void write_cartridge(u16 address, u8 data)
     struct cartridge_header *rom = HEADER(cartridge);
 
     if (rom->type == ROM_ONLY) {
+        assert(address < cartridge.rom_size);
         cartridge.rom[address] = data;
     } else if (rom->type <= MBC1) {
         write_mbc1(address, data);

--- a/src/cartridge/memory.c
+++ b/src/cartridge/memory.c
@@ -26,20 +26,7 @@ u8 read_cartridge(u16 address)
 
 u16 read_cartridge_16bit(u16 address)
 {
-    struct cartridge_header *rom = HEADER(cartridge);
-
-    if (rom->type == ROM_ONLY) {
-        return cartridge.rom[address] + (cartridge.rom[address + 1] << 8);
-    } else if (rom->type <= MBC1) {
-        return read_mbc1_16bit(address);
-    } else if (rom->type <= MBC2) {
-        return read_mbc2_16bit(address);
-    } else if (rom->type <= MBC3) {
-        return read_mbc3_16bit(address);
-    }
-
-    // TODO: invalid cartridge type
-    return cartridge.rom[address] + (cartridge.rom[address + 1] << 8);
+    return read_cartridge(address) + (read_cartridge(address + 1) << 8);
 }
 
 void write_cartridge(u16 address, u8 data)
@@ -59,16 +46,6 @@ void write_cartridge(u16 address, u8 data)
 
 void write_cartridge_16bit(u16 address, u16 data)
 {
-    struct cartridge_header *rom = HEADER(cartridge);
-
-    if (rom->type == ROM_ONLY) {
-        cartridge.rom[address] = LSB(data);
-        cartridge.rom[address + 1] = MSB(data);
-    } else if (rom->type <= MBC1) {
-        write_mbc1_16bit(address, data);
-    } else if (rom->type <= MBC2) {
-        write_mbc2_16bit(address, data);
-    } else if (rom->type <= MBC3) {
-        write_mbc3_16bit(address, data);
-    }
+    write_cartridge(address, LSB(data));
+    write_cartridge(address + 1, MSB(data));
 }

--- a/tests/src/cartridges/cartridge.hxx
+++ b/tests/src/cartridges/cartridge.hxx
@@ -25,6 +25,7 @@ template <uint rom_size, uint ram_size = 1> class CartridgeGenerator
         cart_ = {.filename = "/home/user/nope",
                  .multicart = false,
                  .rom_size = rom_size,
+                 .ram_size = ram_size,
                  .rom = rom_,
                  .ram = ram_};
     }

--- a/tests/src/cartridges/mbc1.cc
+++ b/tests/src/cartridges/mbc1.cc
@@ -21,11 +21,13 @@ class MBC1Generator : public CartridgeGenerator<rom, ram>,
   public:
     MBC1Generator() : CartridgeGenerator<rom, ram>(MBC1) {}
 
-    void SetUp()
+    void SetUp() override
     {
         // Manually set the newly generated cartridge as loaded
-        cartridge = this->cart_;
+        cartridge = this->GetCart();
     };
+
+    void TearDown() override {}
 
   private:
     inline void enable_ram()
@@ -35,7 +37,7 @@ class MBC1Generator : public CartridgeGenerator<rom, ram>,
 };
 
 // 2 MiB ROM & 32 KiB RAM
-class MBC1_Registers : public MBC1Generator<1 << 21, 1 << 15>
+class MBC1_Registers : public MBC1Generator<1 << 21, 1 << 16>
 {
 };
 
@@ -115,7 +117,7 @@ TEST_F(MBC1_Registers, RAMBankNumber)
 // When writing to 0x6000 - 0x7FFF, switch between RAM and ROM banking mode
 TEST_F(MBC1_Registers, BankingModeSelect)
 {
-    const auto address = 0x5025;
+    const auto address = 0x6025;
 
     // default value
     ASSERT_EQ(chip_registers.mode, 0);

--- a/tests/src/cartridges/mbc1.cc
+++ b/tests/src/cartridges/mbc1.cc
@@ -37,9 +37,7 @@ class MBC1Generator : public CartridgeGenerator<rom, ram>,
 };
 
 // 2 MiB ROM & 32 KiB RAM
-class MBC1_Registers : public MBC1Generator<1 << 21, 1 << 16>
-{
-};
+using MBC1_Registers = MBC1Generator<1 << 21, 1 << 16>;
 
 // Update RAM access when writing to 0x0000 -> 0x1FFF
 TEST_F(MBC1_Registers, EnableRAM)

--- a/tests/src/cartridges/mbc1.cc
+++ b/tests/src/cartridges/mbc1.cc
@@ -70,20 +70,20 @@ TEST_F(MBC1_Registers, ROMBankNumber)
     const auto address = 0x3113;
 
     // The lower bits can never be set to 0 and should be set to 1 instead
-    ASSERT_TRUE(chip_registers.bank_1 != 0);
+    ASSERT_TRUE(chip_registers.rom_bank != 0);
 
-    chip_registers.bank_1 = 1;
+    chip_registers.rom_bank = 1;
 
     write_mbc1(address, 0x03);
-    ASSERT_EQ(chip_registers.bank_1, 0x03);
+    ASSERT_EQ(chip_registers.rom_bank, 0x03);
 
     // Higher bits are discarded
     write_mbc1(address, 0xE1);
-    ASSERT_EQ(chip_registers.bank_1, 0x01);
+    ASSERT_EQ(chip_registers.rom_bank, 0x01);
 
     // When writing 0, automatically change it to one
     write_mbc1(address, 0);
-    ASSERT_EQ(chip_registers.bank_1, 1);
+    ASSERT_EQ(chip_registers.rom_bank, 1);
 }
 
 // If the ROM Bank Number is set to a higher value than the number of banks in
@@ -100,16 +100,16 @@ TEST_F(MBC1_Registers, RAMBankNumber)
 {
     const auto address = 0x5025;
 
-    ASSERT_EQ(chip_registers.bank_2, 0);
+    ASSERT_EQ(chip_registers.ram_bank, 0);
 
     write_mbc1(address, 0b0101);
-    ASSERT_EQ(chip_registers.bank_2, 1);
+    ASSERT_EQ(chip_registers.ram_bank, 1);
 
     write_mbc1(address, 0b0011);
-    ASSERT_EQ(chip_registers.bank_2, 3);
+    ASSERT_EQ(chip_registers.ram_bank, 3);
 
     write_mbc1(address, 0xFC);
-    ASSERT_EQ(chip_registers.bank_2, 0);
+    ASSERT_EQ(chip_registers.ram_bank, 0);
 }
 
 // When writing to 0x6000 - 0x7FFF, switch between RAM and ROM banking mode
@@ -153,8 +153,8 @@ class MBC1RWGenerator : public MBC1Generator<rom, ram>,
         const auto &param = GetParam();
 
         ram_access = param.ram_access;
-        chip_registers.bank_1 = param.rom_bank;
-        chip_registers.bank_2 = param.ram_bank;
+        chip_registers.rom_bank = param.rom_bank;
+        chip_registers.ram_bank = param.ram_bank;
         chip_registers.mode = param.mode;
 
         if (ram_access)
@@ -209,6 +209,10 @@ INSTANTIATE_TEST_SUITE_P(
         (struct mbc1_rw_param){0x21B3, 0x69, false, 0x12, 0b01, 0, 0x21B3},
         (struct mbc1_rw_param){0x21B3, 0x69, false, 0x12, 0b01, 1, 0x821B3},
         (struct mbc1_rw_param){0x72A7, 0x42, false, 0x04, 0b10, 1, 0x1132A7},
+
+        // rom_bank 0 -> 1 in this range
+        (struct mbc1_rw_param){0x4000, 0x42, false, 0x00, 0b00, 1, 0x4000},
+
         // RAM
         (struct mbc1_rw_param){0xB123, 0x77, true, 0x12, 0b10, 0, 0x1123},
         (struct mbc1_rw_param){0xB123, 0x77, true, 0x12, 0b10, 1, 0x5123},

--- a/tests/src/cartridges/mbc2.cc
+++ b/tests/src/cartridges/mbc2.cc
@@ -59,33 +59,33 @@ TEST_F(MBC2_Registers, RAMEnable)
     ASSERT_FALSE(ram_access);
 
     // Write 0xA with BIT 8 set: do not change
-    const auto tmp = chip_registers.rom_b;
+    const auto tmp = chip_registers.rom_bank;
     write_mbc2(0x3FF, 0xA);
     ASSERT_FALSE(ram_access);
-    chip_registers.rom_b = tmp;
+    chip_registers.rom_bank = tmp;
 }
 
 TEST_F(MBC2_Registers, ROMBankNumber)
 {
     // When BIT 8 is set: control ROM
     // Set to 1 by default
-    ASSERT_EQ(chip_registers.rom_b, 1);
+    ASSERT_EQ(chip_registers.rom_bank, 1);
 
     // The lower 4 bits of the address control the rom bank number
     write_mbc2(0x10F, 0xF);
-    ASSERT_EQ(chip_registers.rom_b, 0xF);
+    ASSERT_EQ(chip_registers.rom_bank, 0xF);
 
     write_mbc2(0x10A, 0x3A);
-    ASSERT_EQ(chip_registers.rom_b, 0xA);
+    ASSERT_EQ(chip_registers.rom_bank, 0xA);
 
     // Similar to MBC1, can never be null and should be replaced by 1
     write_mbc2(0x100, 0x0);
-    ASSERT_EQ(chip_registers.rom_b, 0x1);
+    ASSERT_EQ(chip_registers.rom_bank, 0x1);
 
     // Value shouldn't change when the address' 8th BIT is clear
-    chip_registers.rom_b = 0xA;
+    chip_registers.rom_bank = 0xA;
     write_mbc2(0x20A, 0xF);
-    ASSERT_EQ(chip_registers.rom_b, 0xA);
+    ASSERT_EQ(chip_registers.rom_bank, 0xA);
 }
 
 struct mbc2_rw_param {
@@ -108,7 +108,7 @@ class MBC2RWGenerator : public MBC2Generator<rom>,
     {
         const auto &param = GetParam();
 
-        chip_registers.rom_b = param.rom_bank;
+        chip_registers.rom_bank = param.rom_bank;
         if (param.ram_access)
             this->enable_ram();
 

--- a/tests/src/cartridges/mbc2.cc
+++ b/tests/src/cartridges/mbc2.cc
@@ -159,9 +159,10 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(
         // ROM
         (struct mbc2_rw_param){0x12A7, 0x42, false, 0x4, 0x12A7},
-        (struct mbc2_rw_param){0x54C1, 0x42, false, 0x4, 0x94C1},
+        (struct mbc2_rw_param){0x54C1, 0x42, false, 0x4, 0x114C1},
         (struct mbc2_rw_param){0x0000, 0x42, true, 0x4, 0x0000},
-        (struct mbc2_rw_param){0x7FFF, 0x42, true, 0xF, 0x1FFFF}, // Max value
+        (struct mbc2_rw_param){0x7FFF, 0x42, true, 0xF, 0x3FFFF}, // Max value
+        (struct mbc2_rw_param){0x4000, 0x42, true, 0x0, 0x4000},
         // RAM
         (struct mbc2_rw_param){0xA1FF, 0x42, true, 0x4, 0x1FF},
         (struct mbc2_rw_param){0xA01B, 0x42, true, 0x4, 0x01B},


### PR DESCRIPTION
We are now able to read and write to the cartridges RAM banks (0xA000-0xBFFF).

## Fix

- Fixed the `ram_access` variable not being set correctly when writing to mbc1 and 2's ram access register. 
- We now read from bank 1 when the `rom_banking` register is set to 0 and reading from 0x4000-0x7FFF