### PR TITLE
misc: add support for CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A Game Boy emulator written from scratch in C.
 - gcc
 - make __OR__ cmake
 
-If using Nix, you can download all requirements through `nix-shell`.
+If using Nix, you can download all requirements through `nix develop`.
 
 ### Linux / MacOs
 
-You can build using either Make or CMake.
+You can build the project using either Make or CMake.
 
 ```sh
 # Using make
@@ -22,9 +22,25 @@ make
 # Using CMake
 mkdir build
 cd build && cmake ..
-make
+make -j4 gb-emu
+```
+
+## Usage
+
+```
+Usage: emu-gb [OPTION...] CARTRIDGE
+GB-EMU: Yet another gameboy emulator written in C
+
+  -l, --log-level=LEVEL      Do not output logs of lower importance
+  -s, --silent               Do not show any log
+  -t, --trace                Output traces during execution
+  -b, --blargg               Display the result of blargg's test roms
+  -x, --exit-infinite-loop   Stop execution when encountering an infinite JR
+                             loop
+  -?, --help                 Give this help list
+      --usage                Give a short usage message
 ```
 
 ## TODO
 
-See [TODO](TODO.md).
+See [TODO](TODO.md)

--- a/include/options.h
+++ b/include/options.h
@@ -11,6 +11,8 @@ struct options {
     char *args[GBEMU_NB_ARGS];
     bool trace;
     log_level log_level;
+    bool exit_infinite_loop;
+    bool blargg;
 };
 
 /**

--- a/include/options.h
+++ b/include/options.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <stdbool.h>
+
+#include "utils/log.h"
+
+/// The number of expected arguments
+#define GBEMU_NB_ARGS 1
+
+struct options {
+    char *args[GBEMU_NB_ARGS];
+    bool trace;
+    log_level log_level;
+};
+
+/**
+ * \function parse_options
+ * \brief Parse the program's options from its CLI arguments
+ * \param argc The number of arguments
+ * \param argv NULL terminated array of arguments
+ */
+struct options *parse_options(int argc, char **argv);
+
+/**
+ * \function get_options
+ * \brief Get the program's current options
+ * \return A pointer to the option struct
+ */
+struct options *get_options(void);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
     utils STATIC
     log.c
+    options.c
     )
 
 add_subdirectory(CPU)

--- a/src/CPU/instruction.c
+++ b/src/CPU/instruction.c
@@ -36,7 +36,7 @@ INSTRUCTION(jp)
 INSTRUCTION(jr)
 {
     if (get_options()->exit_infinite_loop && (i8)in.data == -2) {
-        fatal_error("Infinite  JR loop");
+        fatal_error("Infinite JR loop");
     }
 
     if (!in.condition)

--- a/src/CPU/instruction.c
+++ b/src/CPU/instruction.c
@@ -5,6 +5,7 @@
 #include "CPU/flag.h"
 #include "CPU/interrupt.h"
 #include "CPU/stack.h"
+#include "options.h"
 #include "utils/error.h"
 #include "utils/log.h"
 
@@ -34,8 +35,13 @@ INSTRUCTION(jp)
 
 INSTRUCTION(jr)
 {
+    if (get_options()->exit_infinite_loop && (i8)in.data == -2) {
+        fatal_error("Infinite  JR loop");
+    }
+
     if (!in.condition)
         return in.cycle_count_false;
+
     write_register_16bit(REG_PC, read_register_16bit(REG_PC) + (i8)in.data);
     return in.cycle_count_false;
 }

--- a/src/CPU/instruction_display.c
+++ b/src/CPU/instruction_display.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include "CPU/instruction.h"
+#include "options.h"
 #include "utils/log.h"
 #include "utils/macro.h"
 
@@ -25,6 +26,9 @@ char *register_names[] = {"A",  "F",  "B",  "C",  "D",  "E",  "H",  "L",
 
 void display_instruction(struct instruction in)
 {
+    if (get_options()->trace == false)
+        return;
+
     char *line = NULL;
     char *operands = NULL;
 

--- a/src/log.c
+++ b/src/log.c
@@ -6,6 +6,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "options.h"
+
 #define COLOR_RESET "\033[0m"
 
 const char *level_colors[] = {
@@ -17,6 +19,12 @@ const char *level_colors[] = {
 
 void log_print(log_level level, const char *fmt, ...)
 {
+    const struct options *opt = get_options();
+
+    // Don't output if the importance level is lower than the one requested
+    if (level < opt->log_level)
+        return;
+
     va_list args;
     va_start(args, fmt);
 
@@ -31,6 +39,11 @@ void log_print(log_level level, const char *fmt, ...)
 
 void log_color(const char *color, const char *fmt, ...)
 {
+    // Don't output if the importance level is lower than the one requested.
+    // As the level is not specified, default to LOG_INFO
+    if (get_options()->log_level > LOG_INFO)
+        return;
+
     va_list args;
     va_start(args, fmt);
 

--- a/src/log.c
+++ b/src/log.c
@@ -13,7 +13,7 @@
 const char *level_colors[] = {
     [LOG_INFO] = "\033[1;34m",    // cyan
     [LOG_TRACE] = "\033[1;30m",   // dark grey
-    [LOG_WARNING] = "\033[1;30m", // yellow
+    [LOG_WARNING] = "\033[1;33m", // yellow
     [LOG_ERROR] = "\033[1;31m",   // red
 };
 

--- a/src/main.c
+++ b/src/main.c
@@ -39,10 +39,10 @@ int main(int argc, char **argv)
             timer_ticks(CYCLE_TICKS);
         }
 
-#if 1
-        test_rom_update();
-        test_rom_print();
-#endif
+        if (options->blargg) {
+            test_rom_update();
+            test_rom_print();
+        }
     }
 
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -5,18 +5,16 @@
 #include "CPU/interrupt.h"
 #include "CPU/timer.h"
 #include "cartridge/cartridge.h"
+#include "options.h"
 #include "test_rom.h"
 #include "utils/log.h"
 #include "utils/macro.h"
 
 int main(int argc, char **argv)
 {
-    if (argc < 1) {
-        fputs("No cartridge provided.", stderr);
-        return 1;
-    }
+    const struct options *options = parse_options(argc, argv);
 
-    load_cartridge(argv[1]);
+    load_cartridge(options->args[0]);
     cartridge_info();
 
     reset_cpu();

--- a/src/options.c
+++ b/src/options.c
@@ -41,6 +41,9 @@ static error_t parse_opt(int key, char *value, struct argp_state *state)
         arguments->blargg = true;
         break;
 
+    case 's':
+        arguments->log_level = -1;
+        break;
     case 'l':
         if (STR_EQ(value, "TRACE"))
             arguments->log_level = LOG_TRACE;
@@ -80,6 +83,7 @@ static struct argp_option long_options[] = {
     // Log related
     {"trace", 't', 0, 0, "Output traces during execution"},
     {"log-level", 'l', "LEVEL", 0, "Do not output logs of lower importance"},
+    {"silent", 's', 0, 0, "Do not show any log"},
 
     // Runtime
     {"blargg", 'b', 0, 0, "Display the result of blargg's test roms"},

--- a/src/options.c
+++ b/src/options.c
@@ -34,6 +34,12 @@ static error_t parse_opt(int key, char *value, struct argp_state *state)
     case 't':
         arguments->trace = true;
         break;
+    case 'x':
+        arguments->exit_infinite_loop = true;
+        break;
+    case 'b':
+        arguments->blargg = true;
+        break;
 
     case 'l':
         if (STR_EQ(value, "TRACE"))
@@ -74,6 +80,11 @@ static struct argp_option long_options[] = {
     // Log related
     {"trace", 't', 0, 0, "Output traces during execution"},
     {"log-level", 'l', "LEVEL", 0, "Do not output logs of lower importance"},
+
+    // Runtime
+    {"blargg", 'b', 0, 0, "Display the result of blargg's test roms"},
+    {"exit-infinite-loop", 'x', 0, 0,
+     "Terminate the program when encountering an infinite JR loop"},
 
     {0},
 };

--- a/src/options.c
+++ b/src/options.c
@@ -19,6 +19,8 @@ inline struct options *get_options(void)
     static struct options options = {
         .log_level = LOG_INFO,
         .trace = false,
+        .blargg = false,
+        .exit_infinite_loop = false,
     };
 
     return &options;
@@ -79,16 +81,21 @@ static error_t parse_opt(int key, char *value, struct argp_state *state)
 static char doc[] = "GB-EMU: Yet another gameboy emulator written in C";
 static char args_doc[] = "CARTRIDGE";
 
+#define LOG_GROUP 0
+#define RUNTIME_GROUP 1
+
 static struct argp_option long_options[] = {
     // Log related
-    {"trace", 't', 0, 0, "Output traces during execution"},
-    {"log-level", 'l', "LEVEL", 0, "Do not output logs of lower importance"},
-    {"silent", 's', 0, 0, "Do not show any log"},
+    {"trace", 't', 0, 0, "Output traces during execution", LOG_GROUP},
+    {"log-level", 'l', "LEVEL", 0, "Do not output logs of lower importance",
+     LOG_GROUP},
+    {"silent", 's', 0, 0, "Do not show any log", LOG_GROUP},
 
     // Runtime
-    {"blargg", 'b', 0, 0, "Display the result of blargg's test roms"},
+    {"blargg", 'b', 0, 0, "Display the result of blargg's test roms",
+     RUNTIME_GROUP},
     {"exit-infinite-loop", 'x', 0, 0,
-     "Terminate the program when encountering an infinite JR loop"},
+     "Stop execution when encountering an infinite JR loop", RUNTIME_GROUP},
 
     {0},
 };

--- a/src/options.c
+++ b/src/options.c
@@ -67,7 +67,7 @@ static error_t parse_opt(int key, char *value, struct argp_state *state)
     return 0;
 }
 
-static char doc[] = "gb-emu: yet another gameboy emulator written in C";
+static char doc[] = "GB-EMU: Yet another gameboy emulator written in C";
 static char args_doc[] = "CARTRIDGE";
 
 static struct argp_option long_options[] = {
@@ -77,6 +77,7 @@ static struct argp_option long_options[] = {
 
     {0},
 };
+
 struct options *parse_options(int argc, char **argv)
 {
     static struct argp argp = {long_options, parse_opt, args_doc, doc};

--- a/src/options.c
+++ b/src/options.c
@@ -1,0 +1,88 @@
+/**
+ * \file options.c
+ * \creator Léo DUBOIN <leo@duboin.com>
+ *
+ * Parse the program's CLI arguments using glibc's argp library.
+ *
+ * Documentation: https://girishjoshi.io/post/glibc-argument-parsing-argp/
+ */
+
+#include "options.h"
+
+#include <argp.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <string.h>
+
+inline struct options *get_options(void)
+{
+    static struct options options = {
+        .log_level = LOG_INFO,
+        .trace = false,
+    };
+
+    return &options;
+}
+
+#define STR_EQ(str1, str2) !strcmp((str1), (str2))
+
+static error_t parse_opt(int key, char *value, struct argp_state *state)
+{
+    struct options *arguments = state->input;
+
+    switch (key) {
+    case 't':
+        arguments->trace = true;
+        break;
+
+    case 'l':
+        if (STR_EQ(value, "TRACE"))
+            arguments->log_level = LOG_TRACE;
+        else if (STR_EQ(value, "WARNING"))
+            arguments->log_level = LOG_WARNING;
+        else if (STR_EQ(value, "ERROR"))
+            arguments->log_level = LOG_ERROR;
+        else {
+            log_warn("Invalid argument for option -l / --log-level: %s", value);
+            arguments->log_level = LOG_INFO;
+        }
+        break;
+
+    case ARGP_KEY_ARG:
+        // Too many arguments, if your program expects only one argument.
+        if (state->arg_num > GBEMU_NB_ARGS)
+            argp_usage(state);
+        arguments->args[state->arg_num] = value;
+        break;
+
+    case ARGP_KEY_END:
+        if (state->arg_num < GBEMU_NB_ARGS)
+            argp_usage(state);
+        break;
+
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
+}
+
+static char doc[] = "gb-emu: yet another gameboy emulator written in C";
+static char args_doc[] = "CARTRIDGE";
+
+static struct argp_option long_options[] = {
+    // Log related
+    {"trace", 't', 0, 0, "Output traces during execution"},
+    {"log-level", 'l', "LEVEL", 0, "Do not output logs of lower importance"},
+
+    {0},
+};
+struct options *parse_options(int argc, char **argv)
+{
+    static struct argp argp = {long_options, parse_opt, args_doc, doc};
+    struct options *arguments = get_options();
+
+    argp_parse(&argp, argc, argv, 0, 0, arguments);
+
+    return get_options();
+}

--- a/src/test_rom.c
+++ b/src/test_rom.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 
 #include "CPU/memory.h"
+#include "utils/log.h"
 #include "utils/macro.h"
 
 static char output[1024] = {0};
@@ -19,5 +20,5 @@ void test_rom_update()
 void test_rom_print()
 {
     if (output[0])
-        printf(">> test result: %s\n", output);
+        log_info("test result: %s", output);
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,4 +30,4 @@ make -j4 ld_test
 ## ROMs
 
 I've taken these ROM files from [rokytriton's Game Boy emulator](https://github.com/rockytriton/LLD_gbemu/tree/main/roms).  
-To use them it is necessary to compile using `-DTEST_ROM`. They should display wether the test passed (or run indefinitely ...).
+To use them it is necessary to run with `--blargg`. They should display wether the test passed (or run indefinitely ...).


### PR DESCRIPTION
Parse CLI arguments instead of relying on compile time constant of macro definition.

### New options
```
  -l, --log-level=LEVEL      Do not output logs of lower importance
  -s, --silent               Do not show any log
  -t, --trace                Output traces during execution
  -b, --blargg               Display the result of blargg's test roms
  -x, --exit-infinite-loop   Stop execution when encountering an infinite JR
                             loop
```