### PR TITLE
cpu: fix blargg's tests 4, 8 and 9

### DIFF
--- a/include/CPU/flag.h
+++ b/include/CPU/flag.h
@@ -24,7 +24,7 @@ ALWAYS_INLINE void set_all_flags(bool z, bool n, bool h, bool c)
 
 ALWAYS_INLINE bool get_flag(u16 flag)
 {
-    return cpu.registers.f & flag;
+    return cpu.registers.f & flag ? 1 : 0;
 }
 
 ALWAYS_INLINE u16 get_all_flags()

--- a/include/utils/macro.h
+++ b/include/utils/macro.h
@@ -6,9 +6,9 @@
     fprintf(stderr, ">> Not implemented: %s\n", _feature)
 
 // nth bit from a number x
-#define BIT(_x, _n) ((_x) & (0x1 << (_n)))
+#define BIT(_x, _n) (((_x) & (0x1 << (_n))) >> (_n))
 
-// reverse byte order
+// reverse nybble order
 #define REVERSE(_x) (((_x) >> 4) & ((_x) << 4))
 
 // most/least significant byte in a 16-bit long number

--- a/include/utils/macro.h
+++ b/include/utils/macro.h
@@ -2,11 +2,8 @@
 
 #include <stdio.h>
 
-#define NOT_IMPLEMENTED(_feature) \
-    fprintf(stderr, ">> Not implemented: %s\n", _feature)
-
 // nth bit from a number x
-#define BIT(_x, _n) (((_x) & (0x1 << (_n))) >> (_n))
+#define BIT(_x, _n) (((_x) >> (_n)) & 0x1)
 
 // reverse nybble order
 #define REVERSE(_x) (((_x) >> 4) & ((_x) << 4))

--- a/src/CPU/instruction.c
+++ b/src/CPU/instruction.c
@@ -301,8 +301,16 @@ INSTRUCTION(adc)
                   ? in.data
                   : read_register_16bit(in.reg2);
 
+    u8 half = (val & 0xF) + (added & 0xF) + get_flag(FLAG_C);
+    u16 carry = val + added + get_flag(FLAG_C);
+
     added += get_flag(FLAG_C);
+
     write_register_16bit(in.reg1, static_add(val, added, in.type == HL_R16));
+
+    set_flag(FLAG_H, half & 0x10);
+    set_flag(FLAG_C, carry & 0x100);
+
     return in.cycle_count;
 }
 
@@ -322,8 +330,15 @@ INSTRUCTION(sbc)
                    ? in.data
                    : read_register_16bit(in.reg2);
 
+    u8 half_borrow = (val & 0xF) - (subbed & 0xF) - get_flag(FLAG_C);
+    u16 borrow = val - subbed - get_flag(FLAG_C);
+
     subbed += get_flag(FLAG_C);
     write_register_16bit(in.reg1, static_sub(val, subbed, in.type == HL_R16));
+
+    set_flag(FLAG_H, half_borrow & 0x10);
+    set_flag(FLAG_C, borrow & 0x100);
+
     return in.cycle_count;
 }
 

--- a/src/CPU/instruction.c
+++ b/src/CPU/instruction.c
@@ -400,22 +400,32 @@ INSTRUCTION(rla)
 {
     u8 a = read_register(REG_A);
     u8 c = get_flag(FLAG_C);
+
     set_flag(FLAG_C, BIT(a, 7)); // Copy 7th bit form A to carry flag
-    write_register(REG_A, (a << 1) + c);
+
+    a = (a << 1) + c;
+    write_register(REG_A, a);
 
     set_flag(FLAG_H, false);
     set_flag(FLAG_N, false);
+    set_flag(FLAG_Z, a == 0);
+
     return in.cycle_count;
 }
 
 INSTRUCTION(rlca)
 {
     u8 a = read_register(REG_A);
-    set_flag(FLAG_C, BIT(a, 7)); // Copy 7th bit form A to carry flag
-    write_register(REG_A, (a << 1) + get_flag(FLAG_C));
+
+    set_flag(FLAG_C, BIT(a, 7)); // Copy 7th bit from A to carry flag
+
+    a = (a << 1) + BIT(a, 7);
+    write_register(REG_A, a);
 
     set_flag(FLAG_H, false);
     set_flag(FLAG_N, false);
+    set_flag(FLAG_Z, a == 0);
+
     return in.cycle_count;
 }
 

--- a/src/CPU/instruction.c
+++ b/src/CPU/instruction.c
@@ -331,13 +331,15 @@ INSTRUCTION(sbc)
                    : read_register_16bit(in.reg2);
 
     u8 half_borrow = (val & 0xF) - (subbed & 0xF) - get_flag(FLAG_C);
-    u16 borrow = val - subbed - get_flag(FLAG_C);
+    i16 borrow = val - subbed - get_flag(FLAG_C);
 
-    subbed += get_flag(FLAG_C);
-    write_register_16bit(in.reg1, static_sub(val, subbed, in.type == HL_R16));
+    val -= subbed + get_flag(FLAG_C);
+    write_register(in.reg1, val);
 
+    set_flag(FLAG_Z, val == 0);
     set_flag(FLAG_H, half_borrow & 0x10);
-    set_flag(FLAG_C, borrow & 0x100);
+    set_flag(FLAG_C, borrow < 0);
+    set_flag(FLAG_N, true);
 
     return in.cycle_count;
 }

--- a/src/CPU/instruction.c
+++ b/src/CPU/instruction.c
@@ -404,12 +404,12 @@ INSTRUCTION(rla)
 
     set_flag(FLAG_C, BIT(a, 7)); // Copy 7th bit form A to carry flag
 
-    a = (a << 1) + c;
+    a = (a << 1) | c;
     write_register(REG_A, a);
 
     set_flag(FLAG_H, false);
     set_flag(FLAG_N, false);
-    set_flag(FLAG_Z, a == 0);
+    set_flag(FLAG_Z, false);
 
     return in.cycle_count;
 }
@@ -425,7 +425,7 @@ INSTRUCTION(rlca)
 
     set_flag(FLAG_H, false);
     set_flag(FLAG_N, false);
-    set_flag(FLAG_Z, a == 0);
+    set_flag(FLAG_Z, false);
 
     return in.cycle_count;
 }
@@ -439,6 +439,8 @@ INSTRUCTION(rra)
 
     set_flag(FLAG_H, false);
     set_flag(FLAG_N, false);
+    set_flag(FLAG_Z, false);
+
     return in.cycle_count;
 }
 
@@ -450,6 +452,8 @@ INSTRUCTION(rrca)
 
     set_flag(FLAG_H, false);
     set_flag(FLAG_N, false);
+    set_flag(FLAG_Z, false);
+
     return in.cycle_count;
 }
 

--- a/src/CPU/instruction.c
+++ b/src/CPU/instruction.c
@@ -317,7 +317,7 @@ INSTRUCTION(adc)
 INSTRUCTION(sub)
 {
     u16 val = read_register_16bit(in.reg1);
-    u16 subbed = (in.type == A_R8) ? read_register(REG_A) : in.data;
+    u16 subbed = (in.type == A_R8) ? read_register(in.reg2) : in.data;
 
     write_register(in.reg1, static_sub(val, subbed, false));
     return in.cycle_count;

--- a/src/CPU/instruction.c
+++ b/src/CPU/instruction.c
@@ -330,14 +330,14 @@ INSTRUCTION(sbc)
                    ? in.data
                    : read_register_16bit(in.reg2);
 
-    u8 half_borrow = (val & 0xF) - (subbed & 0xF) - get_flag(FLAG_C);
+    i8 half_borrow = (val & 0xF) - (subbed & 0xF) - get_flag(FLAG_C);
     i16 borrow = val - subbed - get_flag(FLAG_C);
 
     val -= subbed + get_flag(FLAG_C);
     write_register(in.reg1, val);
 
     set_flag(FLAG_Z, val == 0);
-    set_flag(FLAG_H, half_borrow & 0x10);
+    set_flag(FLAG_H, half_borrow < 0);
     set_flag(FLAG_C, borrow < 0);
     set_flag(FLAG_N, true);
 

--- a/src/CPU/instruction_cb.c
+++ b/src/CPU/instruction_cb.c
@@ -1,5 +1,6 @@
 #include "CPU/flag.h"
 #include "CPU/instruction.h"
+#include "utils/log.h"
 #include "utils/macro.h"
 
 #define CB_INSTRUCTION(_name) static u8 _name(struct cb_instruction in)
@@ -124,18 +125,14 @@ CB_INSTRUCTION(sla)
 CB_INSTRUCTION(sra)
 {
     u8 val = (in.is_address) ? read_memory(in.address) : read_register(in.reg);
-    u8 msb = BIT(val, 7);
-    val = (val >> 1) + (msb << 7);
+
+    set_flag(FLAG_C, val & 0x1);
+    val = (val >> 1) | (val & 0x80);
 
     if (in.is_address)
         write_memory(in.address, val);
     else
         write_register(in.reg, val);
-
-    // C is set to the lsb of val in the original Z80 but the GB's doc sets it
-    // to 0. I don't know if it is an error or an actual change but we'll follow
-    // the GB's doc.
-    set_flag(FLAG_C, 0);
 
     set_flag(FLAG_H, false);
     set_flag(FLAG_N, false);

--- a/src/CPU/instruction_cb.c
+++ b/src/CPU/instruction_cb.c
@@ -124,13 +124,14 @@ CB_INSTRUCTION(sla)
 
 CB_INSTRUCTION(sra)
 {
-    u8 val = (in.is_address) ? read_memory(in.address) : read_register(in.reg);
+    u8 val = (in.is_address) ? read_memory(read_register_16bit(REG_HL))
+                             : read_register(in.reg);
 
     set_flag(FLAG_C, val & 0x1);
     val = (val >> 1) | (val & 0x80);
 
     if (in.is_address)
-        write_memory(in.address, val);
+        write_memory(read_register_16bit(REG_HL), val);
     else
         write_register(in.reg, val);
 

--- a/src/CPU/instruction_display.c
+++ b/src/CPU/instruction_display.c
@@ -139,7 +139,7 @@ void display_instruction(struct instruction in)
         break;
 
     case A_D8_REL:
-        asprintf(&operands, "A, " HEX, in.data);
+        asprintf(&operands, "A, " HEX8, in.data);
         break;
 
     case C_REL_A:
@@ -147,7 +147,7 @@ void display_instruction(struct instruction in)
         break;
 
     case D8_REL_A:
-        asprintf(&operands, "(" HEX "), A", in.address);
+        asprintf(&operands, "(" HEX8 "), A", in.address);
         break;
 
     case A_R8:
@@ -155,7 +155,7 @@ void display_instruction(struct instruction in)
         break;
 
     case A_D8:
-        asprintf(&operands, "A, " HEX, in.data);
+        asprintf(&operands, "A, " HEX8, in.data);
         break;
 
     case A_HL_REL:
@@ -169,13 +169,14 @@ void display_instruction(struct instruction in)
     }
 
 // might be useful later ... we never know
-#if 0
+#if 1
     char *registers = NULL;
     char *parameters = NULL;
     char *opcode = NULL;
 
     // print instruction's name
-    asprintf(&opcode, "[" HEX "] %-4.4s ", in.pc, instruction_names[in.instruction]);
+    asprintf(&opcode, "[" HEX "] %-4.4s ", in.pc,
+             instruction_names[in.instruction]);
 
     // print 3 bytes at pc address: opcode + operands
     asprintf(&parameters, "(%02X %02X %02X) ", read_memory(in.pc),
@@ -194,8 +195,8 @@ void display_instruction(struct instruction in)
     free(registers);
 #else
     // print instruction's name
-    asprintf(&line, "[" HEX "] %-4.4s %s", in.pc,
-             instruction_names[in.instruction], operands);
+    asprintf(&line, "[" HEX "] %-4.4s %s \t(" HEX8 ")", in.pc,
+             instruction_names[in.instruction], operands, read_memory(in.pc));
     free(operands);
 #endif
 

--- a/src/CPU/instruction_fetch.c
+++ b/src/CPU/instruction_fetch.c
@@ -564,7 +564,7 @@ struct instruction fetch_instruction(u8 opcode)
 
     case D16_REL_SP:
         in.address = read_16bit_data();
-        in.reg1 = read_register_16bit(REG_SP);
+        in.data = read_register_16bit(REG_SP);
         break;
 
     case HLD_A:

--- a/src/CPU/memory.c
+++ b/src/CPU/memory.c
@@ -2,6 +2,7 @@
 
 #include "CPU/cpu.h"
 #include "cartridge/cartridge.h"
+#include "utils/log.h"
 #include "utils/macro.h"
 
 bool ram_access = false;
@@ -13,6 +14,7 @@ void write_memory(u16 address, u8 val)
         return;
     }
 
+    // log_warn("Writing to an unsupported range: " HEX16, address);
     cpu.memory[address] = val;
 }
 
@@ -33,6 +35,8 @@ u8 read_memory(u16 address)
     if (address < ROM_BANK_SWITCHABLE) {
         return read_cartridge(address);
     }
+
+    // log_warn("Reading from an unsupported range: " HEX16, address);
 
     return cpu.memory[address];
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -102,6 +102,10 @@ NewTest(NAME "cpl" PREFIX "cpu/instructions"
         SRCS "src/cpu/instructions/logical/cpl.cc"
         DEPS cpu cartridge)
 
+NewTest(NAME "sra" PREFIX "cpu/instructions"
+        SRCS "src/cpu/instructions/shift/sra.cc"
+        DEPS cpu cartridge)
+
 
 # CARTRIDGES
 NewTest(NAME "rom"  PREFIX "cartridge" SRCS "src/cartridges/rom.cc" DEPS cartridge cpu)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,10 @@ NewTest(NAME "sra" PREFIX "cpu/instructions"
         SRCS "src/cpu/instructions/shift/sra.cc"
         DEPS cpu cartridge)
 
+NewTest(NAME "rla" PREFIX "cpu/instructions"
+        SRCS "src/cpu/instructions/shift/rla.cc"
+        DEPS cpu cartridge)
+
 
 # CARTRIDGES
 NewTest(NAME "rom"  PREFIX "cartridge" SRCS "src/cartridges/rom.cc" DEPS cartridge cpu)

--- a/tests/src/cpu/instructions/arithmetic/sbc.cc
+++ b/tests/src/cpu/instructions/arithmetic/sbc.cc
@@ -94,7 +94,7 @@ TEST_P(SbcRegisterToA, Sub)
 TEST_P(SbcHLRelativeToA, Sub)
 {
     const auto &param = GetParam();
-    constexpr auto hl = 0x7FFF;
+    constexpr auto hl = 0x7FF8;
     cpu.registers.a = param.x;
     write_register_16bit(REG_HL, hl);
     write_memory(hl, param.y);
@@ -146,7 +146,7 @@ INSTANTIATE_TEST_SUITE_P(borrow, SbcRegisterToA,
 CASES(easy, hl_rel_to_a) = {
     {0x00, 0x00, 0x00, 0x00, {.z = true}},
     {0x02, 0x00, true, 0x01,},
-    {0x85, 0x43, true, 0xC7,},
+    {0x85, 0x43, true, 0x41,},
 };
 
 CASES(borrow, hl_rel_to_a) = {

--- a/tests/src/cpu/instructions/arithmetic/sbc.cc
+++ b/tests/src/cpu/instructions/arithmetic/sbc.cc
@@ -101,7 +101,7 @@ TEST_P(SbcHLRelativeToA, Sub)
     execute_instruction();
 }
 
-TEST_P(SbcImmediateToA, Sub)
+TEST_P(SbcImmediateToA, 0xDE)
 {
     const auto &param = GetParam();
     cpu.registers.a = param.x;
@@ -178,6 +178,18 @@ CASES(borrow, immediate_to_a) = {
     {.x = 0x00, .c = true, .y = 0x00, .expected = 0xFF, .flags = {.c = true, .h = true}},
     {.x = 0x00, .c = false, .y = 0x01, .expected = 0xFF, .flags = {.c = true, .h = true}},
     {.x = 0xFF, .c = true, .y = 0xFF, .expected = 0xFF, .flags = {.c = true, .h = true}},
+};
+
+CASES(blargg, immediate_to_a) = {
+    {.x = 0x00, .c = false, .y = 0x00, .expected = 0x00},
+    {.x = 0x00, .c = false, .y = 0x01, .expected = 0xFF, .flags = {.c = true, .h = true}},
+    {.x = 0x00, .c = false, .y = 0x0F, .expected = 0xF1, .flags = {.c = true}},
+    {.x = 0x00, .c = false, .y = 0x10, .expected = 0xF0, .flags = {.c = true}},
+    {.x = 0x00, .c = false, .y = 0x1F, .expected = 0xE1, .flags = {.c = true}},
+    {.x = 0x00, .c = false, .y = 0x7F, .expected = 0x81, .flags = {.c = true}},
+    {.x = 0x00, .c = false, .y = 0x80, .expected = 0x80, .flags = {.c = true}},
+    {.x = 0x00, .c = false, .y = 0xF0, .expected = 0xF0, .flags = {.c = true}},
+    {.x = 0x00, .c = false, .y = 0xFF, .expected = 0xF0, .flags = {.c = true}},
 };
 // clang-format on
 

--- a/tests/src/cpu/instructions/arithmetic/sub.cc
+++ b/tests/src/cpu/instructions/arithmetic/sub.cc
@@ -121,7 +121,7 @@ CASES(registers, from_register) = {
     {0xFF, 0x01, 0xFE, {false, false, true, false}, 0x93, REG_E},
     {0xFF, 0x01, 0xFE, {false, false, true, false}, 0x94, REG_H},
     {0xFF, 0x01, 0xFE, {false, false, true, false}, 0x95, REG_L},
-    {0xFF, 0xFF, 0x00, {false, false, true, true}, 0x96, REG_A},
+    {0xFF, 0xFF, 0x00, {false, false, true, true}, 0x97, REG_A},
 };
 
 CASES(borrow, from_register) = {

--- a/tests/src/cpu/instructions/instruction.hxx
+++ b/tests/src/cpu/instructions/instruction.hxx
@@ -5,6 +5,7 @@
 
 extern "C" {
 #include <CPU/flag.h>
+#include <options.h>
 }
 
 #include "../../cartridges/cartridge.hxx"
@@ -23,6 +24,7 @@ class InstructionTest : public ::testing::Test
     {
         cpu.registers.pc = start_pc_;
         set_all_flags(false, false, false, false);
+        get_options()->trace = true;
     }
 
     virtual void TearDown() override

--- a/tests/src/cpu/instructions/instruction.hxx
+++ b/tests/src/cpu/instructions/instruction.hxx
@@ -24,7 +24,7 @@ class InstructionTest : public ::testing::Test
     {
         cpu.registers.pc = start_pc_;
         set_all_flags(false, false, false, false);
-        get_options()->trace = true;
+        get_options()->trace = false; // Manually set the value when needed
     }
 
     virtual void TearDown() override

--- a/tests/src/cpu/instructions/load/relative.cc
+++ b/tests/src/cpu/instructions/load/relative.cc
@@ -204,13 +204,14 @@ class RelativeToFF00 : public InstructionTest
 
 TEST_F(SPToImmediateAddress, LoadRelative)
 {
-    const u8 instruction[3] = {0x08, 0x42, 0x24};
+    const u16 address = 0x1234;
+    const u8 instruction[3] = {0x08, LSB(address), MSB(address)};
 
-    cpu.registers.sp = 0x1234;
+    cpu.registers.sp = address;
     Load((void *)instruction);
     execute_instruction();
 
-    ASSERT_EQ(read_memory_16bit(0x2442), cpu.registers.sp);
+    ASSERT_EQ(read_memory_16bit(address), cpu.registers.sp);
 }
 
 TEST_F(RelativeToFF00, OffsetFromC)

--- a/tests/src/cpu/instructions/shift/rla.cc
+++ b/tests/src/cpu/instructions/shift/rla.cc
@@ -31,7 +31,7 @@ using RLCA = RLA;
     execute_instruction();                                   \
     ASSERT_EQ(get_flag(FLAG_C), BIT(val, 7) ? 1 : 0);        \
     ASSERT_EQ(read_register(reg) & 0xFE, (val << 1) & 0xFE); \
-    ASSERT_EQ(get_flag(FLAG_Z), read_register(REG_A) == 0);
+    ASSERT_EQ(get_flag(FLAG_Z), false);
 
 TEST_F(RLA, ImmediateValue)
 {

--- a/tests/src/cpu/instructions/shift/rla.cc
+++ b/tests/src/cpu/instructions/shift/rla.cc
@@ -1,0 +1,68 @@
+// REG_ERR is also defined inside gtest ...
+#define REG_ERR REG_ERR_
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+#include <gtest/gtest_pred_impl.h>
+#undef REG_ERR
+
+extern "C" {
+#include <CPU/cpu.h>
+#include <CPU/instruction.h>
+#include <utils/log.h>
+}
+
+#include "../instruction.hxx"
+
+namespace cpu_tests
+{
+
+class RLA : public InstructionTest
+{
+  public:
+    RLA() : InstructionTest(1) {}
+};
+
+using RLCA = RLA;
+
+#define TEST_RLA(c_)                                         \
+    cpu.registers.pc = pc;                                   \
+    set_flag(FLAG_C, (c_));                                  \
+    write_register(reg, val);                                \
+    execute_instruction();                                   \
+    ASSERT_EQ(get_flag(FLAG_C), BIT(val, 7) ? 1 : 0);        \
+    ASSERT_EQ(read_register(reg) & 0xFE, (val << 1) & 0xFE); \
+    ASSERT_EQ(get_flag(FLAG_Z), read_register(REG_A) == 0);
+
+TEST_F(RLA, ImmediateValue)
+{
+    const auto &reg = REG_A;
+    u8 instr[1] = {0x17};
+    const auto pc = cpu.registers.pc;
+
+    InstructionTest::Load((void *)instr);
+
+    for (u16 val = 0; val <= 0xFF; ++val) {
+        TEST_RLA(true);
+        ASSERT_TRUE(read_register(reg) & 0x01);
+        TEST_RLA(false);
+        ASSERT_FALSE(read_register(reg) & 0x01);
+    }
+}
+
+TEST_F(RLCA, ImmediateValue)
+{
+    const auto &reg = REG_A;
+    u8 instr[1] = {0x07};
+    const auto pc = cpu.registers.pc;
+
+    InstructionTest::Load((void *)instr);
+
+    for (u16 val = 0; val <= 0xFF; ++val) {
+        TEST_RLA(true);
+        ASSERT_EQ(BIT(cpu.registers.a, 0), BIT(val, 7));
+        TEST_RLA(false);
+        ASSERT_EQ(BIT(cpu.registers.a, 0), BIT(val, 7));
+    }
+}
+
+} // namespace cpu_tests

--- a/tests/src/cpu/instructions/shift/sra.cc
+++ b/tests/src/cpu/instructions/shift/sra.cc
@@ -1,0 +1,83 @@
+// REG_ERR is also defined inside gtest ...
+#define REG_ERR REG_ERR_
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+#include <gtest/gtest_pred_impl.h>
+#undef REG_ERR
+
+extern "C" {
+#include <CPU/cpu.h>
+#include <CPU/instruction.h>
+#include <utils/log.h>
+}
+
+#include "../instruction.hxx"
+
+namespace cpu_tests
+{
+
+template <uint size, typename param_type>
+class SRA : public InstructionTest,
+            public ::testing::WithParamInterface<param_type>
+{
+  public:
+    SRA() : InstructionTest(size) {}
+};
+
+using SRA_Register = SRA<2, cpu_register_name>;
+class SRA_Relative : public InstructionTest
+{
+  public:
+    SRA_Relative() : InstructionTest(2) {}
+};
+
+TEST_F(SRA_Relative, RightRotate)
+{
+    const auto pc = cpu.registers.pc;
+    u8 instr[2] = {0xCB, 0x2E};
+    InstructionTest::Load((void *)instr);
+
+    const u16 address = 0x1234;
+    cpu.registers.h = MSB(address);
+    cpu.registers.l = LSB(address);
+
+    for (u16 val = 0; val <= 0xFF; ++val) {
+        cpu.registers.pc = pc;
+        write_memory(address, val);
+        execute_instruction();
+        ASSERT_EQ(get_flag(FLAG_C), val & 0x1);                    // Flag C
+        ASSERT_EQ(read_memory(address) & 0x7F, (val >> 1) & 0x7F); // Core
+        ASSERT_EQ(read_memory(address) & 0x80, val & 0x80);        // Bit 7
+    }
+}
+
+TEST_P(SRA_Register, RightRotate)
+{
+    const auto &reg = GetParam();
+    u8 instr[2] = {0xCB, 0x2F};
+    const auto pc = cpu.registers.pc;
+
+    ASSERT_TRUE(!IS_16BIT(reg));
+
+    if (reg != REG_A)
+        instr[1] = 0x28 + (reg - REG_B);
+
+    get_options()->trace = false;
+
+    InstructionTest::Load((void *)instr);
+
+    for (u16 val = 0; val <= 0xFF; ++val) {
+        cpu.registers.pc = pc;
+        write_register(reg, val);
+        execute_instruction();
+        ASSERT_EQ(get_flag(FLAG_C), val & 0x1);                  // Flag C
+        ASSERT_EQ(read_register(reg) & 0x7F, (val >> 1) & 0x7F); // Core
+        ASSERT_EQ(read_register(reg) & 0x80, val & 0x80);        // Bit 7
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(Registers, SRA_Register,
+                         ::testing::Values(REG_B, REG_C, REG_D, REG_E, REG_H,
+                                           REG_L, REG_A));
+
+} // namespace cpu_tests

--- a/tests/src/cpu/instructions/shift/sra.cc
+++ b/tests/src/cpu/instructions/shift/sra.cc
@@ -62,8 +62,6 @@ TEST_P(SRA_Register, RightRotate)
     if (reg != REG_A)
         instr[1] = 0x28 + (reg - REG_B);
 
-    get_options()->trace = false;
-
     InstructionTest::Load((void *)instr);
 
     for (u16 val = 0; val <= 0xFF; ++val) {


### PR DESCRIPTION
## Fixed

### 04
- ADC: correct implementation of the carry flags
- SBC: read an 8bit value instead of a 16bit one

### 09
- Bit Rotation (RRA, RLA, ...): unset Z flag after execution
- SRA: set carry flag + actually read from HL for relative addressing

### Other
- SUB: was always reading the value from A