### PR TITLE
unit-tests: Add unit-tests to nix flake check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,9 @@ target_link_libraries(emu-gb PRIVATE utils cpu cartridge)
 if (ENABLE_INSTALL)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_BUILD_TYPE}")
     install(TARGETS emu-gb)
+    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/tests/"
+            DESTINATION "tests"
+            )
 endif()
 
 # DOCUMENTATION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,9 @@ if (ENABLE_INSTALL)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_BUILD_TYPE}")
     install(TARGETS emu-gb)
     install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/tests/"
-            DESTINATION "tests"
-            )
+        DESTINATION "tests"
+        USE_SOURCE_PERMISSIONS
+        )
 endif()
 
 # DOCUMENTATION

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,11 +1,18 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 GRAY='\033[0;30m'
 NC='\033[0m' # No color
 
-if [[ ! -d result/tests ]]; then
+TEST_DIR=$1
+
+if [[ -z "$TEST_DIR" ]]; then
+    echo -e "${RED}USAGE$NC: ./run-tests.sh <test_dir>"
+    exit 127
+fi
+
+if [[ ! -d "$TEST_DIR" ]]; then
     echo -e "$RED<!> Couldn't find test binaries (in result/tests) <!>$NC"
     exit 127
 fi
@@ -13,25 +20,26 @@ fi
 FAILED=0
 VERBOSE=$(test "$1" = "-v"; echo $?)
 
-cd result/tests
+cd "$TEST_DIR" || exit
 
 echo -e "====${GRAY} Running tests in result/tests $NC===="
 
-for test in $(find * -type f -and -executable); do
+tests=$(find -- * -type f -and -executable)
+
+for test in $tests; do
     if [[ $VERBOSE -eq 0 ]]; then
         echo -e "$GRAY======== Running $test ========$NC"
         "./$test"
         FAILED=$((FAILED + 1))
     else
-        echo -ne "$GREY- $test: $NC"
-        "./$test" &> /dev/null
-        if [[ $? -eq 0 ]]; then
+        echo -ne "- $test:"
+        if "./$test" &> /dev/null; then
             echo -e "${GREEN}OK"
         else
             FAILED=$((FAILED + 1))
             echo -e "${RED}KO"
         fi
-        echo -ne $NC
+        echo -ne "$NC"
     fi
 done
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,16 +18,16 @@ function(NewTest)
         ${ARGN}
     )
 
-    set(test "${TEST_NAME}_test")
+    set(TEST "${TEST_NAME}_test")
     set(TEST_NAME "${TEST_PREFIX}/${TEST_NAME}")
 
-    add_executable(${test} ${TEST_SRCS})
-    add_custom_command(TARGET ${test} PRE_BUILD COMMAND ${CMAKE_COMMAND} -E make_directory ${TEST_PREFIX})
-    target_link_libraries(${test} PRIVATE ${TEST_DEPS} ${GTEST_BOTH_LIBRARIES})
-    set_target_properties(${test} PROPERTIES OUTPUT_NAME ${TEST_NAME})
+    add_executable(${TEST} ${TEST_SRCS})
+    add_custom_command(TARGET ${TEST} PRE_BUILD COMMAND ${CMAKE_COMMAND} -E make_directory ${TEST_PREFIX})
+    target_link_libraries(${TEST} PRIVATE ${TEST_DEPS} ${GTEST_BOTH_LIBRARIES})
+    set_target_properties(${TEST} PROPERTIES OUTPUT_NAME ${TEST_NAME})
     add_test(NAME "${TEST_NAME}" COMMAND ${TEST_NAME})
 
-    gtest_discover_tests("${test}")
+    gtest_discover_tests("${TEST}")
 
 endfunction()
 


### PR DESCRIPTION
The testsuite can now automatically be run using `nix flake check`
(Along with pre-commits (See #16) )